### PR TITLE
calculate missing fields if they are missing

### DIFF
--- a/src/field.rs
+++ b/src/field.rs
@@ -38,8 +38,8 @@ impl Field {
     self.bson_types.contains(&FieldType::get_type(&value))
   }
 
-  pub fn get_path(name: String, path: &Option<String>) -> String {
-    match &path {
+  pub fn get_path(name: String, path: Option<String>) -> String {
+    match path {
       None => name,
       Some(path) => {
         let mut path = path.clone();
@@ -54,6 +54,10 @@ impl Field {
     self.count += 1
   }
 
+  pub fn update_count_by(&mut self, num: usize) {
+    self.count += num
+  }
+
   pub fn update_for_missing(&mut self, missing: usize) {
     // create new field_types of "Null" for missing fields.
     let mut null_field_type = FieldType::new(&self.path, &Bson::Null)
@@ -63,6 +67,7 @@ impl Field {
     self
       .types
       .insert("Null".to_string(), null_field_type.to_owned());
+    self.update_count_by(missing);
   }
 
   pub fn set_probability(&mut self, parent_count: usize) {
@@ -100,7 +105,7 @@ mod tests {
 
   #[test]
   fn it_gets_path_if_none() {
-    let path = Field::get_path(String::from("address"), &None);
+    let path = Field::get_path(String::from("address"), None);
     assert_eq!(path, String::from("address"));
   }
 
@@ -108,7 +113,7 @@ mod tests {
   fn it_gets_path_if_some() {
     let path = Field::get_path(
       String::from("postal_code"),
-      &Some(String::from("address")),
+      Some(String::from("address")),
     );
     assert_eq!(path, String::from("address.postal_code"));
   }
@@ -118,7 +123,7 @@ mod tests {
     bench.iter(|| {
       Field::get_path(
         String::from("postal_code"),
-        &Some(String::from("address")),
+        Some(String::from("address")),
       )
     });
   }

--- a/src/field.rs
+++ b/src/field.rs
@@ -58,23 +58,11 @@ impl Field {
     // create new field_types of "Null" for missing fields.
     let mut null_field_type = FieldType::new(&self.path, &Bson::Null)
       .add_to_type(&Bson::Null, self.count);
+    self.bson_types.push(null_field_type.bson_type.clone());
     null_field_type.count = missing;
     self
       .types
       .insert("Null".to_string(), null_field_type.to_owned());
-
-    // If bson_types includes a Document, find that document and let its schema
-    // field update its own missing fields.
-    let doc_type = "Document".to_string();
-    if self.bson_types.contains(&doc_type) {
-      let field_type = self.types.get_mut(&doc_type);
-      if let Some(field_type) = field_type {
-        match &mut field_type.schema {
-          Some(sch) => sch.finalize_schema(),
-          None => return,
-        };
-      }
-    }
   }
 
   pub fn set_probability(&mut self, parent_count: usize) {

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -47,8 +47,11 @@ impl FieldType {
       }
       Bson::Document(subdoc) => {
         let mut schema_parser = SchemaParser::new();
-        schema_parser
-          .generate_field(subdoc.to_owned(), &Some(self.path.clone()));
+        schema_parser.generate_field(
+          subdoc.to_owned(),
+          Some(self.path.clone()),
+          Some(&self.count),
+        );
         self.set_schema(schema_parser);
         self
       }
@@ -70,9 +73,11 @@ impl FieldType {
     if &bson_type == "Document" {
       match &mut self.schema {
         Some(schema_parser) => match &value {
-          Bson::Document(subdoc) => {
-            schema_parser.generate_field(subdoc.to_owned(), &Some(path))
-          }
+          Bson::Document(subdoc) => schema_parser.generate_field(
+            subdoc.to_owned(),
+            Some(path),
+            Some(&self.count),
+          ),
           _ => unimplemented!(),
         },
         None => unimplemented!(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -177,10 +177,8 @@ impl SchemaParser {
   /// let schema = schema_parser.read();
   /// println!("{:?}", schema);
   /// ```
-  // might want to rename this to finalize depending on how much manipulation
-  // will have to be done later on.
-  pub fn read(self) -> SchemaParser {
-    self
+  pub fn read(&mut self) -> SchemaParser {
+    self.finalize_schema().to_owned()
   }
 
   /// Returns a serde_json string. This should be called after all values were
@@ -243,6 +241,20 @@ impl SchemaParser {
       field.set_duplicates(has_duplicates);
       field.set_probability(self.count);
     }
+  }
+
+  fn finalize_schema(&mut self) -> &mut SchemaParser {
+    for field in self.fields.values_mut() {
+      let missing = self.count - field.count;
+      if missing > 0 {
+        field.update_for_missing(missing);
+      }
+    }
+    self
+
+    // should check if a field is unique for each field_type and set_unique
+    // should check if field_type has duplicates, set_duplicates on field_tyep,
+    // and set_duplicates on parent.
   }
 
   #[inline]


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
If a given collection of documents has missing fields, we want to be able to account for them.

Example set of documents:
```json
{"name": "Nori", "type": "Cat"}
{"name": "Rey"}
{"name": "Chashu"}
```
Output:
```json
{
  "count": 3,
  "fields": {
    "name": {
      "name": "name",
      "path": "name",
      "count": 3,
      "bson_types": [
        "String"
      ],
      "probability": 1,
      "has_duplicates": false,
      "types": {
        "String": {
          "path": "name",
          "count": 3,
          "bson_type": "String",
          "probability": 1,
          "values": [
            "Nori",
            "Rey",
            "Chashu"
          ],
          "has_duplicates": false,
          "unique": 3
        }
      }
    },
    "type": {
      "name": "type",
      "path": "type",
      "count": 3,
      "bson_types": [
        "String",
        "Null"
      ],
      "probability": 0,
      "has_duplicates": false,
      "types": {
        "Null": {
          "path": "type",
          "count": 2,
          "bson_type": "Null",
          "probability": 1,
          "has_duplicates": false,
          "unique": null
        },
        "String": {
          "path": "type",
          "count": 1,
          "bson_type": "String",
          "probability": 1,
          "values": [
            "Cat"
          ],
          "has_duplicates": false,
          "unique": null
        }
      }
    }
  }
}
```