### PR TITLE
WASM API to return a js_sys::Object

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_derive = "^1.0.59"
 bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-suport" } 
 wee_alloc = "0.4.2"
 console_error_panic_hook = "0.1.5"
-js-sys = "0.3.16"
+js-sys = "0.3.25"
 web-sys = { version = "0.3.16", features = ['console'] }
 
 [dependencies.wasm-bindgen]

--- a/README.md
+++ b/README.md
@@ -67,8 +67,12 @@ var schemaWasm = import('@mongodb-rust/wasm-schema-parser')
 
 schemaWasm.then(module => {
   var schemaParser = new module.SchemaParser()
-  schemaParser.writeJson('{"name": "Chashu", "type": "Norwegian Forest Cat"}')
-  var result = schemaParser.toJson()
+  try {
+    schemaParser.writeJson('{"name": "Chashu", "type": "Norwegian Forest Cat"}')
+  } catch (e) {
+    throw new Error("schema-parser: Could not write Json", e)
+  }
+  var result = schemaParser.toObject()
   console.log(result)
 })
 .catch(e => console.error('Cannot load @mongodb-rust/wasm-schema-parser', e))
@@ -87,6 +91,10 @@ Writes a document in a form of `json` string to SchemaParser.
 
 ### `schema = schemaParser.toJson()`
 Returns parsed schema in `json` form.
+
+### `schema = schemaParser.toObject()`
+Returns parsed schema as a JavaScript Object. Eliminates the need to call
+`JSON.parse()` on a JSON string.
 
 ## Installation
 ```sh

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,7 @@ impl SchemaParser {
   /// # Examples
   /// ```
   /// use mongodb_schema_parser::SchemaParser;
+  ///
   /// let mut schema_parser = SchemaParser::new();
   /// let json = r#"{ "name": "Chashu", "type": "Cat" }"#;
   /// schema_parser.write_json(&json);
@@ -192,6 +193,7 @@ impl SchemaParser {
   /// # Examples
   /// ```
   /// use mongodb_schema_parser::SchemaParser;
+  ///
   /// let mut schema_parser = SchemaParser::new();
   /// let json = r#"{ "name": "Chashu", "type": "Cat" }"#;
   /// schema_parser.write_json(&json);
@@ -202,16 +204,6 @@ impl SchemaParser {
   #[inline]
   pub fn to_json(&self) -> Result<String, failure::Error> {
     Ok(serde_json::to_string(&self)?)
-  }
-
-  pub fn to_js_object(&self) -> Result<Object, failure::Error> {
-    let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
-    let js_obj = Object::try_from(&js_val);
-    if let Some(js_obj) = js_obj {
-      Ok(js_obj.clone())
-    } else {
-      Err(format_err!("Cannot create JavaScript Object from Schema."))
-    }
   }
 
   #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -88,6 +88,10 @@ use crate::field_type::FieldType;
 mod value_type;
 use crate::value_type::ValueType;
 
+// WASM Api of the Schema Parser.
+mod lib_wasm;
+use crate::lib_wasm::*;
+
 #[wasm_bindgen]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SchemaParser {
@@ -284,97 +288,6 @@ impl SchemaParser {
   #[inline]
   fn update_count(&mut self) {
     self.count += 1
-  }
-}
-
-// Need to wrap schema parser impl for wasm suppport.
-// Here we are wrapping the exported to JS land methods and mathing on Result to
-// turn the error message to JsValue.
-#[wasm_bindgen]
-impl SchemaParser {
-  /// Wrapper method for `SchemaParser::new()` to be used in JavaScript.
-  /// `wasm_bindgen(js_name = "new")`
-  ///
-  /// ```js, ignore
-  /// import { SchemaParser } from "mongodb-schema-parser";
-  ///
-  /// var schemaParser = new SchemaParser()
-  /// ````
-  #[wasm_bindgen(constructor)]
-  #[wasm_bindgen(js_name = "new")]
-  pub fn wasm_new() -> Self {
-    Self::new()
-  }
-
-  /// Wrapper method for `schema_parser.write_json()` to be used in JavaScript.
-  /// `wasm_bindgen(js_name = "writeJson")`
-  ///
-  ///
-  /// ```js, ignore
-  /// import { SchemaParser } from "mongodb-schema-parser"
-  ///
-  /// var schemaParser = new SchemaParser()
-  /// var json = "{"name": "Nori", "type": "Cat"}"
-  /// schemaParser.writeJson(json)
-  /// ````
-  #[wasm_bindgen(js_name = "writeJson")]
-  pub fn wasm_write_json(&mut self, json: &str) -> Result<(), JsValue> {
-    match self.write_json(json) {
-      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-      _ => Ok(()),
-    }
-  }
-
-  #[wasm_bindgen(js_name = "writeRaw")]
-  pub fn wasm_write_raw(&mut self, uint8: Uint8Array) -> Result<(), JsValue> {
-    match self.write_raw(uint8) {
-      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-      _ => Ok(()),
-    }
-  }
-
-  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
-  /// `wasm_bindgen(js_name = "toJson")`
-  ///
-  /// ```js, ignore
-  /// import { SchemaParser } from "mongodb-schema-parser"
-  ///
-  /// var schemaParser = new SchemaParser()
-  /// var json = "{"name": "Nori", "type": "Cat"}"
-  /// schemaParser.writeJson(json)
-  /// // get the result as a json string
-  /// var result = schemaParser.toJson()
-  /// console.log(result) //
-  /// ````
-  #[wasm_bindgen(js_name = "toJson")]
-  pub fn wasm_to_json(&mut self) -> Result<String, JsValue> {
-    self.flush();
-    match self.to_json() {
-      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-      Ok(val) => Ok(val),
-    }
-  }
-
-  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
-  /// `wasm_bindgen(js_name = "toJson")`
-  ///
-  /// ```js, ignore
-  /// import { SchemaParser } from "mongodb-schema-parser"
-  ///
-  /// var schemaParser = new SchemaParser()
-  /// var json = "{"name": "Nori", "type": "Cat"}"
-  /// schemaParser.writeJson(json)
-  /// // get the result as a json string
-  /// var result = schemaParser.toObject()
-  /// console.log(result) //
-  /// ````
-  #[wasm_bindgen(js_name = "toObject")]
-  pub fn wasm_to_js_object(&mut self) -> Result<Object, JsValue> {
-    self.flush();
-    match self.to_js_object() {
-      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-      Ok(val) => Ok(val),
-    }
   }
 }
 

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -1,6 +1,8 @@
 use super::SchemaParser;
+use failure::format_err;
 use js_sys::{Object, Uint8Array};
 use wasm_bindgen::prelude::*;
+
 // Need to wrap schema parser impl for wasm suppport.
 // Here we are wrapping the exported to JS land methods and mathing on Result to
 // turn the error message to JsValue.
@@ -88,6 +90,16 @@ impl SchemaParser {
     match self.to_js_object() {
       Err(e) => Err(JsValue::from_str(&format!("{}", e))),
       Ok(val) => Ok(val),
+    }
+  }
+
+  fn to_js_object(&self) -> Result<Object, failure::Error> {
+    let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
+    let js_obj = Object::try_from(&js_val);
+    if let Some(js_obj) = js_obj {
+      Ok(js_obj.clone())
+    } else {
+      Err(format_err!("Cannot create JavaScript Object from Schema."))
     }
   }
 }

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -1,0 +1,93 @@
+use super::SchemaParser;
+use js_sys::{Object, Uint8Array};
+use wasm_bindgen::prelude::*;
+// Need to wrap schema parser impl for wasm suppport.
+// Here we are wrapping the exported to JS land methods and mathing on Result to
+// turn the error message to JsValue.
+#[wasm_bindgen]
+impl SchemaParser {
+  /// Wrapper method for `SchemaParser::new()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "new")`
+  ///
+  /// ```js, ignore
+  /// import { SchemaParser } from "mongodb-schema-parser";
+  ///
+  /// var schemaParser = new SchemaParser()
+  /// ````
+  #[wasm_bindgen(constructor)]
+  #[wasm_bindgen(js_name = "new")]
+  pub fn wasm_new() -> Self {
+    Self::new()
+  }
+
+  /// Wrapper method for `schema_parser.write_json()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "writeJson")`
+  ///
+  ///
+  /// ```js, ignore
+  /// import { SchemaParser } from "mongodb-schema-parser"
+  ///
+  /// var schemaParser = new SchemaParser()
+  /// var json = "{"name": "Nori", "type": "Cat"}"
+  /// schemaParser.writeJson(json)
+  /// ````
+  #[wasm_bindgen(js_name = "writeJson")]
+  pub fn wasm_write_json(&mut self, json: &str) -> Result<(), JsValue> {
+    match self.write_json(json) {
+      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+      _ => Ok(()),
+    }
+  }
+
+  #[wasm_bindgen(js_name = "writeRaw")]
+  pub fn wasm_write_raw(&mut self, uint8: Uint8Array) -> Result<(), JsValue> {
+    match self.write_raw(uint8) {
+      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+      _ => Ok(()),
+    }
+  }
+
+  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "toJson")`
+  ///
+  /// ```js, ignore
+  /// import { SchemaParser } from "mongodb-schema-parser"
+  ///
+  /// var schemaParser = new SchemaParser()
+  /// var json = "{"name": "Nori", "type": "Cat"}"
+  /// schemaParser.writeJson(json)
+  /// // get the result as a json string
+  /// var result = schemaParser.toJson()
+  /// console.log(result) //
+  /// ````
+  #[wasm_bindgen(js_name = "toJson")]
+  pub fn wasm_to_json(&mut self) -> Result<String, JsValue> {
+    self.flush();
+    match self.to_json() {
+      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+      Ok(val) => Ok(val),
+    }
+  }
+
+  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "toJson")`
+  ///
+  /// ```js, ignore
+  /// import { SchemaParser } from "mongodb-schema-parser"
+  ///
+  /// var schemaParser = new SchemaParser()
+  /// var json = "{"name": "Nori", "type": "Cat"}"
+  /// schemaParser.writeJson(json)
+  /// // get the result as a json string
+  /// var result = schemaParser.toObject()
+  /// console.log(result) //
+  /// ````
+  #[wasm_bindgen(js_name = "toObject")]
+  pub fn wasm_to_js_object(&mut self) -> Result<Object, JsValue> {
+    self.flush();
+    match self.to_js_object() {
+      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+      Ok(val) => Ok(val),
+    }
+  }
+}


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
Adds a method to WASM bindings to create JS Object after schema's been finalized. This eliminates the necessity to run JSON.parse after result is returned. So instead of this:
```js
  schemaParser.writeJson('{"name": "Chashu", "type": "Norwegian Forest Cat"}')
  var result = schemaParser.toJson()
  var parsed = JSON.parse(result);
```
we are able to get an object:
```js
  schemaParser.writeJson('{"name": "Chashu", "type": "Norwegian Forest Cat"}')
  var parsed = schemaParser.toObject();
```

This does not affect Rust's API.

## Semver Changes
Minor.

cc @durran 