### PR TITLE
match on all bson types in get_value and get_type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ coverage/
 target/
 tmp/
 dist/
+*.code-workspace
 pkg/
 wasm-pack.log
 npm-debug.log*

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ failure = "0.1.2"
 serde = "^1.0.59"
 serde_json = "^1.0.38"
 serde_derive = "^1.0.59"
-bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-suport" } 
+bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-dec128" } 
 wee_alloc = "0.4.2"
 console_error_panic_hook = "0.1.5"
 js-sys = "0.3.25"

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -239,13 +239,6 @@ mod tests {
     assert_eq!(value, Some(ValueType::Str("cats".to_string())));
   }
 
-  #[test]
-  fn it_gets_value_none() {
-    let bson_value = Bson::TimeStamp(1234);
-    let value = FieldType::get_value(&bson_value);
-    assert_eq!(value, None);
-  }
-
   // #[bench]
   // fn bench_it_gets_value(bench: &mut Bencher) {
   //   let bson_value = Bson::String("cats".to_string());
@@ -391,13 +384,4 @@ mod tests {
   //     FieldType::new("address", &Bson::String("Oranienstr. 123".to_string()));
   //   bench.iter(|| field_type.update_value(&bson_value));
   // }
-
-  #[test]
-  fn it_updates_value_none() {
-    let bson_value = Bson::TimeStamp(1234);
-    let mut field_type =
-      FieldType::new("address", &Bson::String("Oranienstr. 123".to_string()));
-    field_type.update_value(&bson_value);
-    assert!(field_type.values.is_empty());
-  }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl SchemaParser {
   /// let json = r#"{ "name": "Chashu", "type": "Cat" }"#;
   /// schema_parser.write_json(&json);
   /// schema_parser.flush();
-  /// let schema = schema_parser.to_json().unwrap();
+  /// let schema = schema_parser.into_json().unwrap();
   /// println!("{}", schema);
   /// ```
   #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,6 +162,10 @@ impl SchemaParser {
     uint8.copy_to(&mut decoded_vec);
     let mut slice: &[u8] = &decoded_vec;
     let doc = decode_document(&mut slice)?.to_owned();
+    console::log_2(
+      &"can decode document".into(),
+      &JsValue::from_str(&serde_json::to_string(&doc).unwrap()),
+    );
     // write bson internally
     self.update_count();
     self.generate_field(doc, None, None);
@@ -203,6 +207,10 @@ impl SchemaParser {
   /// ```
   #[inline]
   pub fn to_json(&self) -> Result<String, failure::Error> {
+    console::log_2(
+      &"converting to Json".into(),
+      &JsValue::from_str(&serde_json::to_string(&self).unwrap()),
+    );
     Ok(serde_json::to_string(&self)?)
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,10 +162,6 @@ impl SchemaParser {
     uint8.copy_to(&mut decoded_vec);
     let mut slice: &[u8] = &decoded_vec;
     let doc = decode_document(&mut slice)?.to_owned();
-    console::log_2(
-      &"can decode document".into(),
-      &JsValue::from_str(&serde_json::to_string(&doc).unwrap()),
-    );
     // write bson internally
     self.update_count();
     self.generate_field(doc, None, None);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -206,12 +206,9 @@ impl SchemaParser {
   /// println!("{}", schema);
   /// ```
   #[inline]
-  pub fn to_json(&self) -> Result<String, failure::Error> {
-    console::log_2(
-      &"converting to Json".into(),
-      &JsValue::from_str(&serde_json::to_string(&self).unwrap()),
-    );
-    Ok(serde_json::to_string(&self)?)
+  pub fn into_json(mut self) -> Result<String, failure::Error> {
+    let schema = self.flush();
+    Ok(serde_json::to_string(&schema)?)
   }
 
   #[inline]

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -70,36 +70,35 @@ impl SchemaParser {
     }
   }
 
-  // /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
-  // /// `wasm_bindgen(js_name = "toJson")`
-  // ///
-  // /// ```js, ignore
-  // /// import { SchemaParser } from "mongodb-schema-parser"
-  // ///
-  // /// var schemaParser = new SchemaParser()
-  // /// var json = "{"name": "Nori", "type": "Cat"}"
-  // /// schemaParser.writeJson(json)
-  // /// // get the result as a json string
-  // /// var result = schemaParser.toObject()
-  // /// console.log(result) //
-  // /// ````
-  // #[wasm_bindgen(js_name = "toObject")]
-  // pub fn wasm_to_js_object(&mut self) -> Result<String, JsValue> {
-  //   // self.flush();
-  //   Ok(String::from("butts"))
-  //   // match self.to_js_object() {
-  //   //   Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-  //   //   Ok(val) => Ok(val),
-  //   // }
-  // }
+  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
+  /// `wasm_bindgen(js_name = "toJson")`
+  ///
+  /// ```js, ignore
+  /// import { SchemaParser } from "mongodb-schema-parser"
+  ///
+  /// var schemaParser = new SchemaParser()
+  /// var json = "{"name": "Nori", "type": "Cat"}"
+  /// schemaParser.writeJson(json)
+  /// // get the result as a json string
+  /// var result = schemaParser.toObject()
+  /// console.log(result) //
+  /// ````
+  #[wasm_bindgen(js_name = "toObject")]
+  pub fn wasm_to_js_object(&mut self) -> Result<Object, JsValue> {
+    self.flush();
+    match self.to_js_object() {
+      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+      Ok(val) => Ok(val),
+    }
+  }
 
-  // fn to_js_object(&self) -> Result<Object, failure::Error> {
-  //   let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
-  //   let js_obj = Object::try_from(&js_val);
-  //   if let Some(js_obj) = js_obj {
-  //     Ok(js_obj.clone())
-  //   } else {
-  //     Err(format_err!("Cannot create JavaScript Object from Schema."))
-  //   }
-  // }
+  fn to_js_object(&self) -> Result<Object, failure::Error> {
+    let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
+    let js_obj = Object::try_from(&js_val);
+    if let Some(js_obj) = js_obj {
+      Ok(js_obj.clone())
+    } else {
+      Err(format_err!("Cannot create JavaScript Object from Schema."))
+    }
+  }
 }

--- a/src/lib_wasm.rs
+++ b/src/lib_wasm.rs
@@ -63,43 +63,43 @@ impl SchemaParser {
   /// console.log(result) //
   /// ````
   #[wasm_bindgen(js_name = "toJson")]
-  pub fn wasm_to_json(&mut self) -> Result<String, JsValue> {
-    self.flush();
-    match self.to_json() {
+  pub fn wasm_into_json(self) -> Result<String, JsValue> {
+    match self.into_json() {
       Err(e) => Err(JsValue::from_str(&format!("{}", e))),
       Ok(val) => Ok(val),
     }
   }
 
-  /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
-  /// `wasm_bindgen(js_name = "toJson")`
-  ///
-  /// ```js, ignore
-  /// import { SchemaParser } from "mongodb-schema-parser"
-  ///
-  /// var schemaParser = new SchemaParser()
-  /// var json = "{"name": "Nori", "type": "Cat"}"
-  /// schemaParser.writeJson(json)
-  /// // get the result as a json string
-  /// var result = schemaParser.toObject()
-  /// console.log(result) //
-  /// ````
-  #[wasm_bindgen(js_name = "toObject")]
-  pub fn wasm_to_js_object(&mut self) -> Result<Object, JsValue> {
-    self.flush();
-    match self.to_js_object() {
-      Err(e) => Err(JsValue::from_str(&format!("{}", e))),
-      Ok(val) => Ok(val),
-    }
-  }
+  // /// Wrapper method for `schema_parser.to_json()` to be used in JavaScript.
+  // /// `wasm_bindgen(js_name = "toJson")`
+  // ///
+  // /// ```js, ignore
+  // /// import { SchemaParser } from "mongodb-schema-parser"
+  // ///
+  // /// var schemaParser = new SchemaParser()
+  // /// var json = "{"name": "Nori", "type": "Cat"}"
+  // /// schemaParser.writeJson(json)
+  // /// // get the result as a json string
+  // /// var result = schemaParser.toObject()
+  // /// console.log(result) //
+  // /// ````
+  // #[wasm_bindgen(js_name = "toObject")]
+  // pub fn wasm_to_js_object(&mut self) -> Result<String, JsValue> {
+  //   // self.flush();
+  //   Ok(String::from("butts"))
+  //   // match self.to_js_object() {
+  //   //   Err(e) => Err(JsValue::from_str(&format!("{}", e))),
+  //   //   Ok(val) => Ok(val),
+  //   // }
+  // }
 
-  fn to_js_object(&self) -> Result<Object, failure::Error> {
-    let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
-    let js_obj = Object::try_from(&js_val);
-    if let Some(js_obj) = js_obj {
-      Ok(js_obj.clone())
-    } else {
-      Err(format_err!("Cannot create JavaScript Object from Schema."))
-    }
-  }
+  // fn to_js_object(&self) -> Result<Object, failure::Error> {
+  //   let js_val = JsValue::from_serde(&serde_json::to_value(&self)?)?;
+  //   let js_obj = Object::try_from(&js_val);
+  //   if let Some(js_obj) = js_obj {
+  //     Ok(js_obj.clone())
+  //   } else {
+  //     Err(format_err!("Cannot create JavaScript Object from Schema."))
+  //   }
+  // }
 }

--- a/src/value_type.rs
+++ b/src/value_type.rs
@@ -4,6 +4,9 @@ pub enum ValueType {
   Str(String),
   I32(i32),
   I64(i64),
+  Decimal128(String),
   FloatingPoint(f64),
+  Binary(Vec<u8>),
   Boolean(bool),
+  Null(String),
 }

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -12,7 +12,7 @@ fn json_file_gen() -> Result<(), Error> {
     // this panics i think ?
     schema_parser.write_json(&json)?;
   }
-  let schema = schema_parser.to_json();
+  let schema = schema_parser.into_json();
   println!("{:?}", schema);
   Ok(())
 }


### PR DESCRIPTION
## Checklist
- [x] tests pass
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added

## Context
This PR adds decimal128 support. It's still unfortunately based off a branch on bson crate, but it will allow us to publish a WASM crate. 

![Screen Shot 2019-07-17 at 14 13 49](https://user-images.githubusercontent.com/8107784/61594120-1b485b80-abe8-11e9-935f-aeb0660b7791.png)
We've been running into ^ this error when using Decimal128 types in collections. The error came from code hitting a `None` type in our `get_value` function. This is because initially we only parsed the basic types and did not match on anything else.

This PR matches both `get_value` and `get_type` on all existing BSON types that are supported in `bson` crate. 

This PR also includes parsing all different number types to their respective type rather than classifying them all as `Number`. So, `FloatingPoint => Double`, `I64 => Long` etc. 

## Semver Changes
Minor.

cc @durran 