### PR TITLE
Get rid of unwrap, some clones, unneeded refs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 failure = "0.1.2"
-serde = "^1.0.59"
-serde_json = "^1.0.38"
-serde_derive = "^1.0.59"
+serde = "1.0.101"
+serde_json = "1.0.40"
+serde_derive = "1.0.101"
 bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-dec128" } 
 wee_alloc = "0.4.2"
 console_error_panic_hook = "0.1.5"


### PR DESCRIPTION
## Checklist
- [ x ] tests pass
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
Saw your talk (rustconf) and noticed you said you couldn't get rid of an `unwrap()`. I started there and got a bit carried away trying to remove as many allocations as possible. 

I thought it may have been possible to store your `FieldType::get_type` as a `&'static str` and then use `&'static str` everywhere it's used. That would save a ton of allocations and just reference the same wherever they are used, but unfortunately wasm-bindgen doesn't support structs with lifetimes, one way to get it all to work would be to add a `'static` lifetime to `Field` in `SchemaParser`. I'm pretty confident there should be some other way to do it, but I didn't want to keep changing things.

Anyway, I'm not sure if you're even interested in changes like this so feel free to ignore if that's the case. 

## Semver Changes
Doesn't change your public facing API
