### PR TITLE
Upate bson to use released version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ failure = "0.1.2"
 serde = "1.0.101"
 serde_json = "1.0.40"
 serde_derive = "1.0.101"
-bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-dec128" } 
+bson = { version = "0.14.0", features = ["decimal128"] }
 wee_alloc = "0.4.2"
 console_error_panic_hook = "0.1.6"
 js-sys = "0.3.25"


### PR DESCRIPTION
Bson has added decimal support and this crate can use it.

## Checklist
- [-] tests pass (not all tests pass, failures are referencing file(s) which aren't in the repo)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context

The `bson` crate was pinned to a branch on a fork of rust-bson. This fork has fallen behind, and my PR is updating to the released bson crate.

## Semver Changes

None
