### PR TITLE
put wasm behind a feature gate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,17 @@ serde = "1.0.101"
 serde_json = "1.0.40"
 serde_derive = "1.0.101"
 bson = { git = "https://github.com/lrlna/bson-rs", branch = "wasm-dec128" } 
-wee_alloc = "0.4.2"
-console_error_panic_hook = "0.1.6"
-js-sys = "0.3.25"
-web-sys = { version = "0.3.16", features = ['console'] }
-wasm-bindgen-test = "0.3.8"
+wee_alloc = { version = "0.4.2", optional = true }
+console_error_panic_hook = { version = "0.1.6", optional = true }
+js-sys = { version = "0.3.25", optional = true }
+web-sys = { version = "0.3.16", features = ['console'], optional = true }
+wasm-bindgen-test = { version = "0.3.8", optional = true }
 
 [dependencies.wasm-bindgen]
 version = "^0.2.37"
 features = ["serde-serialize"]
+optional = true
+
+[features]
+wasm = ["wee_alloc", "console_error_panic_hook", "js-sys", "web-sys", "wasm-bindgen-test", "wasm-bindgen"]
+default = ["wasm"]

--- a/src/field_type.rs
+++ b/src/field_type.rs
@@ -1,5 +1,7 @@
 #![allow(clippy::option_map_unit_fn)]
-use super::{Bson, SchemaParser, ValueType, HashMap, console};
+#[cfg(feature = "wasm")]
+use super::console;
+use super::{Bson, HashMap, SchemaParser, ValueType};
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct FieldType {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -62,14 +62,19 @@ extern crate serde_derive;
 extern crate serde;
 use serde_json::Value;
 
+#[cfg(feature = "wasm")]
 use js_sys::{Object, Uint8Array};
+#[cfg(feature = "wasm")]
 use wasm_bindgen::prelude::*;
 // add to use console.log to send debugs to js land
+#[cfg(feature = "wasm")]
 use web_sys::console;
 
 // using custom allocator which is built specifically for wasm; makes it smaller
 // + faster
+#[cfg(feature = "wasm")]
 use wee_alloc;
+#[cfg(feature = "wasm")]
 #[global_allocator]
 static ALLOC: wee_alloc::WeeAlloc = wee_alloc::WeeAlloc::INIT;
 
@@ -86,10 +91,12 @@ mod value_type;
 use crate::value_type::ValueType;
 
 // WASM Api of the Schema Parser.
+#[cfg(feature = "wasm")]
 mod lib_wasm;
+#[cfg(feature = "wasm")]
 use crate::lib_wasm::*;
 
-#[wasm_bindgen]
+#[cfg_attr(feature = "wasm", wasm_bindgen)]
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub struct SchemaParser {
   pub count: usize,
@@ -154,6 +161,7 @@ impl SchemaParser {
   /// let uint8 = Uint8Array::new(&JsValue::from_str(r#"{ "name": "Chashu", "type": "Cat" }"#));
   /// schema_parser.write_raw(uint8);
   /// ```
+  #[cfg(feature = "wasm")]
   #[inline]
   pub fn write_raw(&mut self, uint8: Uint8Array) -> Result<(), failure::Error> {
     let mut decoded_vec = vec![0u8; uint8.length() as usize];

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -1,9 +1,14 @@
-use wasm_bindgen_test::*;
-use mongodb_schema_parser::SchemaParser;
-use web_sys::console;
+#[cfg(feature = "wasm")]
 use js_sys::Uint8Array;
+use mongodb_schema_parser::SchemaParser;
+#[cfg(feature = "wasm")]
 use wasm_bindgen::JsValue;
+#[cfg(feature = "wasm")]
+use wasm_bindgen_test::*;
+#[cfg(feature = "wasm")]
+use web_sys::console;
 
+#[cfg(feature = "wasm")]
 #[wasm_bindgen_test]
 fn test_binary_sales_supplies() {
   // documents that failed with an unreachable error in js land


### PR DESCRIPTION
## Checklist
- [-] tests pass (those that don't require a file that's not commited)
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added

## Context
This puts `wasm` behind a feature-gate, but leaves it as a default feature such that it's opt-out.

## Semver Changes

Minor?

Closes #37 
